### PR TITLE
Use Object.hash instead of hashValues to support Flutter 3.27

### DIFF
--- a/lib/src/models/lat_lon.dart
+++ b/lib/src/models/lat_lon.dart
@@ -31,5 +31,5 @@ class LatLon {
   }
 
   @override
-  int get hashCode => hashValues(latitude, longitude);
+  int get hashCode => Object.hash(latitude, longitude);
 }


### PR DESCRIPTION
With Flutter 3.27 release, `hashValues` function has been removed. To keep the package compatible with newer versions of Flutter, `Object.hash` should be used instead.